### PR TITLE
Add labels to cronjob pod template

### DIFF
--- a/charts/templates/cronjob.yaml
+++ b/charts/templates/cronjob.yaml
@@ -11,9 +11,9 @@ spec:
       template:
         metadata:
           labels: 
-            {{- with .Values.podLabels }}
-            {{ toYaml . }}
-            {{- end }}
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 12}}
+{{- end }}
         spec:
           serviceAccountName: {{ include "argocd-ecr-updater.serviceAccountName" . }}
           containers:

--- a/charts/templates/cronjob.yaml
+++ b/charts/templates/cronjob.yaml
@@ -9,6 +9,11 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels: 
+            {{- with .Values.podLabels }}
+            {{ toYaml . }}
+            {{- end }}
         spec:
           serviceAccountName: {{ include "argocd-ecr-updater.serviceAccountName" . }}
           containers:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -42,6 +42,9 @@ podAnnotations: {}
 #  prometheus.io/path: "metrics"
 #  prometheus.io/port: "8080"
 
+podLabels: {}
+#  team: infra
+
 service:
   httpPort: "8080"
 


### PR DESCRIPTION
We need to be able to add labels to pods created by the cronJob. This PR adds the possibility.